### PR TITLE
Scan Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ We can get a little more information about the annotation by passing the verbose
 
 ![issue-summoner-scan-verbose](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/e9dc9ffc-40ff-4e78-b06e-5730e10a5e47)
 
-You may have noticed that there is not a description. This is because single line comments are used for concise comments. However, we can be more granular by utilizing a multi line comment:
+You may have noticed that there is not a description. This is because single line comments are concise. However, we can be more granular by utilizing a multi line comment:
 
 ```c
 #include <stdio.h>

--- a/README.md
+++ b/README.md
@@ -124,43 +124,65 @@ go install github.com/AntoninoAdornetto/go-issue-summoner@latest
 
 ## Usage
 
-Annotations are scanned and located through single and multi line comments. Lets take a look at an example using a single line comment in go:
+### Scan Command
 
-```go
-// @TODO handle error in main function
-// we should not ignore the error that may be returned from `importantFunc`
-func main(){
-  data, _ := importantFunc()
+Scans your local git project for comments that contain an issue annotation. Issues are objects that are built when scanning the project. In short, they describe a task, concern, or area of code that requires attention. The scan command is a preliminary command that may be used prior to the `report` command. This will give you an idea of the issue annotations that reside in your project. Heck, even if you did not want to use the tool to publish the issues to a source code platform, you could utilize the tool by running the scan command locally to keep track of what items need attention.
+
+- `-a`, `--annotation` The annotation the program will search for. (default annotation is @TODO)
+
+- `-p`, `--path` The path to your local git repository (defaults to your current working directory if a path is not provided)
+
+- `-g`, `--gitignore` The path to your .gitignore file. This is optional, and will default to your current working directory or to the gitignore located at the path you provided from the flag above. You can provide the gitignore file path for projects that you are not scanning. This may be a very niche use case, but it is supported.
+
+- `-m`, `--mode` The two modes are `pending` and `processed`. Meaning that you can scan for annotations that have not been uploaded to a source code management platform, I.E pending, or you can scan for annotations that have been published, I.E processed. Processed annotations will look differently than pending annotations because when issues are reported, the program will update the annotation to include a unique id so the comment can be removed by the program once it has been marked as resolved. (default mode is pending)
+
+- `-v`, `--verbose` Logs detailed information about each issue annotation that was located during the scan.
+
+#### Scan Usage
+
+```sh
+issue-summoner scan
+```
+
+The command will walk your git project directory and check each source file. It adheres to the rules of your projects .gitignore file and skips entire directories and files when it finds a match. Yes, you do not need to worry about your node_modules folder being scanned! The comment syntax to use for each file is based on the files extension. Most languages are supported and more are to come! Let's take a look at an example that uses a single line comment for a C file:
+
+```c
+#include <stdio.h>
+
+// @TODO implement the main function
+int main() {
+	printf("Hello world\n");
+	return 0;
 }
 ```
 
-We add the annotation and the action that should be taken. Next, we run the `scan` command to see information about all of the issues that are using the `@TODO` annotation in our project. We only have one item at this time, but if you had multiple they would all be displayed.
+Basic usage of the command would result in the following:
 
-```sh
-# default tag annotation is @TODO you dont have to specify it, if you use this tag.
-issue-summoner scan --tag @TODO --verbose
+![issue-summoner-scan](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/f9eaef15-ac50-49d1-b8b2-1c0dd72f8393)
 
-Filename:  main.go
-Title:  handle error in main function
-Description:  we should not ignore the error that may be returned from `importantFunc`
-Start Line number:  8
-End Line number:  9
-Annotation Line number:  8
-Multi line comment:  false
-Single line comment:  true
+We can get a little more information about the annotation by passing the verbose flag `-v` the result would be:
 
-Found 1 (@TODO) tag annotations in your project.
+![issue-summoner-scan-verbose](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/e9dc9ffc-40ff-4e78-b06e-5730e10a5e47)
+
+You may have noticed that there is not a description. This is because single line comments are used for concise comments. However, we can be more granular by utilizing a multi line comment:
+
+```c
+#include <stdio.h>
+
+int main() {
+  /*
+   * @TODO implement the main function
+   * The main function does nothing useful.
+   * Remove the print statement and build something that is useful!
+   * */
+  printf("Hello world\n");
+  return 0;
+}
 ```
 
-You can read more about the scan command [here - (does not exist yet)]() but in short, it provides us information about each annotation that is discovered in your source code. If you wanted to report this issue to GitHub, you could then run the following command after [authorizing - (does not exist yet)]() the program to submit issues on your behalf.
+The new result using a multi line comment:
 
-```sh
-issue-summoner report --tag @TODO
-```
-
-Running the above command will provide a multi select option where you can choose which items you would like to report. The default source code management adapter for the `report` command is GitHub. You can read more about the command [here - (does not exist yet)]()
-
-![issue-summoner-report](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/04b8ad6b-0791-4dd7-840f-201796d75c97)
+![issue-summoner-scan-2](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/f065c8d5-7a7a-4d61-b8d4-fab388f40fe7)
 
 <!-- _For more examples, please refer to the [Documentation](https://example.com)_ -->
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,20 @@ The new result using a multi line comment:
 
 ![issue-summoner-scan-2](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/f065c8d5-7a7a-4d61-b8d4-fab388f40fe7)
 
+### Authorize Command
+
+In order to publish issues to a source code management system, we must first authorize the program to allow this. Authorizing will look different for each provider. As of now, I have added support for GitHub. I will be adding more in the near future.
+
+- `-s`, `--scm` The source code management platform to authorize. (default is GitHub).
+
+#### Authorize for GitHub
+
+The [device-flow](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) is utilized to create an access token. The only thing you really need to know here is that when you run the command, you will be given a `user code` in the terminal and your default browser will open to https://github.com/login/device You will then be prompted to enter the user code while the program polls the authorization service for an access token. Once the steps are complete, the program will have all scopes it needs to report issues for you. **Note**: this does grant the program access to both public and private repositories.
+
+```sh
+issue-summoner authorize -s github
+```
+
 <!-- _For more examples, please refer to the [Documentation](https://example.com)_ -->
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ The command will walk your git project directory and check each source file. It 
 
 // @TODO implement the main function
 int main() {
-	printf("Hello world\n");
-	return 0;
+    printf("Hello world\n");
+    return 0;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This repo is under active development. I am in the early stages of building out 
 
 [![Product Name Screen Shot][product-screenshot]](https://example.com)
 
-Go Issue Summoner is a tool that will stremline the process of creating issues within your code base. It works by scanning source code files for special annotations (that you define and pass into the program via a flag) and automatically creates issues on a source code management platform of your choosing. This process will ensure that no important task or concern is overlooked.
+Go Issue Summoner is a tool that will streamline the process of creating issues within your code base. It works by scanning source code files for special annotations (that you define and pass into the program via a flag) and automatically creates issues on a source code management platform of your choosing. This process will ensure that no important task or concern is overlooked.
 
 ## Core Features
 

--- a/cmd/authorize.go
+++ b/cmd/authorize.go
@@ -18,11 +18,6 @@ import (
 // in the `allowedPlatforms` slice.
 var allowedPlatforms = []string{scm.GH, scm.GL, scm.BB}
 
-func init() {
-	AuthorizeCmd.Flags().
-		StringP("scm", "s", scm.GH, "What source code manager platform would you like to Authorize?")
-}
-
 // authorizeCmd represents the authorize command
 var AuthorizeCmd = &cobra.Command{
 	Use:   "authorize",
@@ -114,4 +109,9 @@ var AuthorizeCmd = &cobra.Command{
 			),
 		)
 	},
+}
+
+func init() {
+	AuthorizeCmd.Flags().
+		StringP("scm", "s", scm.GH, "What source code manager platform would you like to Authorize?")
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+const (
+	err_unauthorized     = "Please run `issue-summoner authorize` and complete the authorization process. This will allow us to submit issues on your behalf."
+	no_issues            = "No issues were found in your project using the annotation: "
+	found_issues         = "Number of issues found: "
+	tip_verbose          = "Tip: run issue-summoner scan -v (verbose) for more details about the tag annotations that were found"
+	flag_path            = "path"
+	flag_gignore         = "gitignore"
+	flag_mode            = "mode"
+	flag_scm             = "scm"
+	flag_verbose         = "verbose"
+	flag_annotation      = "annotation"
+	shortflag_path       = "p"
+	shortflag_scm        = "s"
+	shortflag_gignore    = "g"
+	shortflag_mode       = "m"
+	shortflag_verbose    = "v"
+	shortflag_annotation = "a"
+	flag_desc_path       = "the path to your local git repository"
+	flag_desc_scm        = "The source code management platform you would like to use. Example: GitHub or GitLab"
+	flag_desc_gignore    = "path to gitignore file"
+	flag_desc_mode       = "'processed' is for issues that have already been pushed to a scm. 'pending' is for issues that have not yet been published"
+	flag_desc_verbose    = "log detailed information about each issue annotation that is located during the scan"
+	flag_desc_annotation = "The issue annotation to search for. Example: @TODO:"
+)
+
+// both the scan and report command will use similar flags
+func handleCommonFlags(cmd *cobra.Command) (annotation string, ignorePath string, path string) {
+	var err error
+	annotation, err = cmd.Flags().GetString(flag_annotation)
+	if err != nil {
+		ui.LogFatal(err.Error())
+	}
+
+	ignorePath, err = cmd.Flags().GetString(flag_gignore)
+	if err != nil {
+		ui.LogFatal(err.Error())
+	}
+
+	path, err = cmd.Flags().GetString(flag_path)
+	if err != nil {
+		ui.LogFatal(err.Error())
+	}
+
+	if path == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+		path = wd
+	}
+
+	if ignorePath == "" {
+		ignorePath = filepath.Join(path, ".gitignore")
+	}
+
+	return annotation, ignorePath, path
+}
+
+func gitIgnorePatterns(ignorePath string) []regexp.Regexp {
+	f, err := os.Open(ignorePath)
+	if err != nil {
+		ui.LogFatal(err.Error())
+	}
+
+	ignorePatterns, err := scm.ParseIgnorePatterns(f)
+	if err != nil {
+		ui.LogFatal(err.Error())
+	}
+
+	return ignorePatterns
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1,15 +1,12 @@
 /*
-Copyright © 2024 Antonino Adornetto
+Copyright © 2024 AntoninoAdornetto
 */
 package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/issue"
-	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
 	"github.com/spf13/cobra"
 )
@@ -18,58 +15,27 @@ var ScanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "scans source code for Issue annotations (actionable comments)",
 	Long: `scans your git project for comments that include issue annotations.
-		The comment is used for reporting purposes to see what actionable comments your
-		project contains. This can give you an idea of all the issues in your code base
-		prior to uploading them to a source code management platform.
-		`,
+Issue annotations can be as simple as @TODO or any annotation that you see
+fit. The only requirement is that the annotation resides in a single or multi
+line comment. Once found, you can see details about the located comment using
+the verbose flag. The scan command is a preliminary command to the report 
+command. Report will actually publish the located comments to your favorite
+source code management platform. Scan is for reviewing the issue annotations
+that reside in your code base.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		annotation, err := cmd.Flags().GetString("annotation")
+		annotation, ignorePath, path := handleCommonFlags(cmd)
+
+		verbose, err := cmd.Flags().GetBool(flag_verbose)
 		if err != nil {
 			ui.LogFatal(err.Error())
 		}
 
-		ignorePath, err := cmd.Flags().GetString("gitignore")
+		mode, err := cmd.Flags().GetString(flag_mode)
 		if err != nil {
 			ui.LogFatal(err.Error())
 		}
 
-		verbose, err := cmd.Flags().GetBool("verbose")
-		if err != nil {
-			ui.LogFatal(err.Error())
-		}
-
-		path, err := cmd.Flags().GetString("path")
-		if err != nil {
-			ui.LogFatal(err.Error())
-		}
-
-		mode, err := cmd.Flags().GetString("mode")
-		if err != nil {
-			ui.LogFatal(err.Error())
-		}
-
-		if path == "" {
-			wd, err := os.Getwd()
-			if err != nil {
-				ui.LogFatal(err.Error())
-			}
-			path = wd
-		}
-
-		if ignorePath == "" {
-			ignorePath = filepath.Join(path, ".gitignore")
-		}
-
-		gitIgnore, err := os.Open(ignorePath)
-		if err != nil {
-			ui.LogFatal(err.Error())
-		}
-
-		ignorePatterns, err := scm.ParseIgnorePatterns(gitIgnore)
-		if err != nil {
-			ui.LogFatal(err.Error())
-		}
-
+		ignorePatterns := gitIgnorePatterns(ignorePath)
 		im, err := issue.NewIssueManager(mode, annotation)
 		if err != nil {
 			ui.LogFatal(err.Error())
@@ -82,35 +48,25 @@ var ScanCmd = &cobra.Command{
 
 		issues := im.GetIssues()
 		if len(issues) > 0 {
-			fmt.Println(
-				ui.SuccessTextStyle.Render(
-					fmt.Sprintf(
-						"\nFound %d (%s) issue annotations in your project.",
-						len(issues),
-						annotation,
-					),
-				),
-			)
+			success := fmt.Sprintf("Found %d issue annotations using %s", len(issues), annotation)
+			fmt.Println(ui.SuccessTextStyle.Render(success))
 		} else {
-			fmt.Println(ui.SecondaryTextStyle.Render(fmt.Sprintf("\nNo tags were located in your project using the annotation %s", annotation)))
+			fmt.Println(ui.SecondaryTextStyle.Render(fmt.Sprintf("%s %s", no_issues, annotation)))
+			return
 		}
 
 		if verbose {
 			issue.PrintTagResults(issues, ui.DimTextStyle, ui.PrimaryTextStyle)
 		} else {
-			fmt.Println(
-				ui.SecondaryTextStyle.Render(
-					"Tip: run issue-summoner scan -v (verbose) for more details about the tag annotations that were found",
-				),
-			)
+			fmt.Println(ui.SecondaryTextStyle.Render(tip_verbose))
 		}
 	},
 }
 
 func init() {
-	ScanCmd.Flags().StringP("path", "p", "", "path to local git repo")
-	ScanCmd.Flags().StringP("gitignore", "g", "", "gitignore file path")
-	ScanCmd.Flags().StringP("mode", "m", "pending", "i = issued | issues or p = pending")
-	ScanCmd.Flags().BoolP("verbose", "v", false, "log information about each issue found")
-	ScanCmd.Flags().StringP("annotation", "a", "@TODO", "Issue Annotation program will search for")
+	ScanCmd.Flags().StringP(flag_path, shortflag_path, "", flag_desc_path)
+	ScanCmd.Flags().StringP(flag_gignore, shortflag_gignore, "", flag_desc_gignore)
+	ScanCmd.Flags().StringP(flag_mode, shortflag_mode, issue.PENDING_ISSUE, flag_desc_mode)
+	ScanCmd.Flags().BoolP(flag_verbose, shortflag_verbose, false, flag_desc_verbose)
+	ScanCmd.Flags().StringP(flag_annotation, shortflag_annotation, "@TODO", flag_desc_annotation)
 }

--- a/pkg/issue/comment.go
+++ b/pkg/issue/comment.go
@@ -165,6 +165,7 @@ func (c *CommentNotation) ParseLine(n *uint64) (Issue, error) {
 			c.AnnotationIndicator = false
 			*n++
 		}
+		issue.EndLineNumber += 1
 	}
 
 	c.AnnotationIndicator = false

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -66,6 +66,8 @@ func NewIssueManager(issueType string, annotation string) (IssueManager, error) 
 	switch issueType {
 	case PENDING_ISSUE:
 		return &PendingIssue{Annotation: annotation}, nil
+	case PROCESSED_ISSUE:
+		return &ProcessedIssue{Annotation: annotation}, nil
 	default:
 		return nil, errors.New("Unsupported issue type. Use 'pending' or 'processed'")
 	}

--- a/pkg/issue/processed.go
+++ b/pkg/issue/processed.go
@@ -15,7 +15,7 @@ func (pi *ProcessedIssue) Walk(root string, ignore []regexp.Regexp) (int, error)
 	return n, nil
 }
 
-func (pi *ProcessedIssue) Scan(r io.Reader) error {
+func (pi *ProcessedIssue) Scan(r io.Reader, path string) error {
 	return nil
 }
 

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	GH = "GitHub"
-	GL = "GitLab"
-	BB = "BitBucket"
+	GH = "github"
+	GL = "gitlab"
+	BB = "bitbucket"
 )
 
 // @TODO can GlobalUserName and RepoName functions be deleted?

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -57,7 +57,7 @@ func (gh *GitHubManager) Report(issues []Issue, scm string) error {
 type createIssueResponse struct {
 	URL           string `json:"url"`
 	RepositoryURL string `json:"repository_url"`
-	LabelsURL     string `json:"labels_url"` // Note that this is a template string, you'll need to replace {name} with the label name in use.
+	LabelsURL     string `json:"labels_url"`
 	CommentsURL   string `json:"comments_url"`
 	EventsURL     string `json:"events_url"`
 	HTMLURL       string `json:"html_url"`


### PR DESCRIPTION
# Changes

- added missing documentation for how to use the `scan` command
- added missing documentation for how to use the `authorize` command with GitHub's device flow
- moved some of the flags that scan uses to a common file. The report command will reuse some of the same flags

# Bug fixes

- multi line comment parsing was resulting in an off by 1 error. This was due to the stack being emptied prior to incrementing the line number counter. 