### PR TITLE
Fix - Error parsing regexp from gitignore file

### DIFF
--- a/pkg/scm/ignore_test.go
+++ b/pkg/scm/ignore_test.go
@@ -15,6 +15,7 @@ func TestParseIgnorePatterns(t *testing.T) {
 		"/tmp",
 		".pnp.js",
 		"*.log",
+		"*.log*",
 		"src/pkg/test/impl/",
 		"# Comment, to be ignored",
 		"",
@@ -29,11 +30,12 @@ func TestParseIgnorePatterns(t *testing.T) {
 	expected := []regexp.Regexp{
 		*regexp.MustCompile(`\/tmp`),
 		*regexp.MustCompile(`.pnp.js`),
-		*regexp.MustCompile(`.*\.log`),
+		*regexp.MustCompile(`.*.log`),
+		*regexp.MustCompile(`.*.log*.`),
 		*regexp.MustCompile(`src/pkg/test/impl/`),
 		*regexp.MustCompile(`\/tmp`),
 		*regexp.MustCompile(`.pnp.js`),
-		*regexp.MustCompile(`.*\.log`),
+		*regexp.MustCompile(`.*.log`),
 		*regexp.MustCompile(`src/pkg/test/impl/`),
 	}
 


### PR DESCRIPTION
`Expected behavior:`  Ensure expressions are compiled correctly when converting a gitignore pattern to a regular expression. More specifically, the prefix and suffix of the expression should be validated and escape characters when necessary. 

`Actual behavior:` The program panics when dealing with git ignore patterns such as `*.log*` because a back slash was appended to every quantifier that was written to the buffer that is in charge of forming the string to be compiled to an expression. The backslash was not escaped. 
