### PR TITLE
Report Issues to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Go Issue Summoner is a tool that will streamline the process of creating issues 
 
 - `Minimized Context Switching`: Developers can write a quick note in their source code file about the issue and then run the report command. Those details will be pushed to the source code management platform you selected and will allow the developer to continue on with their original task with minimal context switching.
 
+- `Discover Issues for contributing to open source projects`: Contributing to open source can be a daunting task. Where does one start? What issue should I tackle first? Well, issue-summoner can be used to locate forgotten issues that may have never been reported and were forgotten about. Simply running `issue-summoner scan` on your favorite open source project may return hundreds of `TODO:` annotations that went under the radar. What a great place to start!
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Built With
@@ -162,7 +164,7 @@ Basic usage of the command would result in the following:
 
 We can get a little more information about the annotation by passing the verbose flag `-v` the result would be:
 
-![issue-summoner-scan-verbose](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/e9dc9ffc-40ff-4e78-b06e-5730e10a5e47)
+![issue-summoner-scan-verbose](https://github.com/AntoninoAdornetto/issue-summoner/assets/70185688/45373977-8828-4f57-9371-6486c634bb52)
 
 You may have noticed that there is not a description. This is because single line comments are concise. However, we can be more granular by utilizing a multi line comment:
 
@@ -182,7 +184,7 @@ int main() {
 
 The new result using a multi line comment:
 
-![issue-summoner-scan-2](https://github.com/AntoninoAdornetto/go-issue-summoner/assets/70185688/f065c8d5-7a7a-4d61-b8d4-fab388f40fe7)
+![issue-summoner-scan-verbose-multi-line](https://github.com/AntoninoAdornetto/issue-summoner/assets/70185688/09313924-2a02-4000-898e-09b2aeca07a1)
 
 ### Authorize Command
 

--- a/cmd/authorize.go
+++ b/cmd/authorize.go
@@ -88,7 +88,7 @@ var authorizeCmd = &cobra.Command{
 			}
 		}()
 
-		gitManager := scm.GetGitConfig(sourceCodeManager)
+		gitManager := scm.NewGitManager(sourceCodeManager)
 		err = gitManager.Authorize()
 		if err != nil {
 			if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2024 AntoninoAdornetto
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/issue"
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+)
+
+var reportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Report pending issues to a source code management platform",
+	Long: `Report will scan your git project for comments that include issue annotations.
+Issue annotations can be as simple as @TODO or any other value that you seefit. 
+The only requirement is that the annotation resides in a single or multi line comment. 
+Once issue annotations are discovered, you will be presented with a list of all the issues 
+that were located and you can select which ones you would like to report to a source code management
+platform.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		annotation, ignorePath, path := handleCommonFlags(cmd)
+
+		sourceCodeManager, err := cmd.Flags().GetString(flag_scm)
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
+		isAuthorized, err := scm.CheckForAccess(sourceCodeManager)
+		if err != nil {
+			if os.IsNotExist(err) {
+				ui.LogFatal(err_unauthorized)
+			} else {
+				ui.LogFatal(err.Error())
+			}
+		}
+
+		if !isAuthorized {
+			ui.LogFatal(err_unauthorized)
+		}
+
+		issueManager, err := issue.NewIssueManager(issue.PENDING_ISSUE, annotation)
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
+		ignorePatterns := gitIgnorePatterns(ignorePath)
+		_, err = issueManager.Walk(path, ignorePatterns)
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
+		issues := issueManager.GetIssues()
+		if len(issues) == 0 {
+			fmt.Println(ui.ErrorTextStyle.Render(no_issues))
+			return
+		}
+
+		selections := ui.Selection{
+			Options: make(map[string]bool),
+		}
+
+		options := make([]ui.Item, len(issues))
+		for i, is := range issues {
+			options[i] = ui.Item{
+				Title: is.Title,
+				Desc:  is.Description,
+				ID:    is.ID,
+			}
+		}
+
+		var quit bool
+		teaProgram := tea.NewProgram(
+			ui.InitialModelMultiSelect(
+				options,
+				&selections,
+				select_issues,
+				&quit,
+			),
+		)
+
+		if _, err := teaProgram.Run(); err != nil {
+			ui.LogFatal(err.Error())
+		}
+
+		staged := make([]scm.Issue, 0)
+		for _, is := range issues {
+			if selections.Options[is.ID] {
+				md, err := is.GenerateIssueTmplMarkdown(issue_template_path)
+				if err != nil {
+					ui.LogFatal(err.Error())
+				}
+				staged = append(
+					staged,
+					scm.Issue{Title: is.Title, Body: string(md)},
+				)
+			}
+		}
+
+		gitManager := scm.NewGitManager(sourceCodeManager)
+		err = gitManager.Report(staged, sourceCodeManager)
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(reportCmd)
+	reportCmd.Flags().StringP(flag_path, shortflag_path, "", flag_desc_path)
+	reportCmd.Flags().StringP(flag_gignore, shortflag_gignore, "", flag_desc_gignore)
+	reportCmd.Flags().StringP(flag_annotation, shortflag_annotation, "@TODO", flag_desc_annotation)
+	reportCmd.Flags().StringP(flag_scm, shortflag_scm, scm.GH, flag_desc_scm)
+}

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -1,9 +1,12 @@
 package issue
 
 import (
+	"bytes"
 	"errors"
 	"regexp"
+	"runtime"
 	"strings"
+	"text/template"
 )
 
 const (
@@ -18,6 +21,7 @@ type Issue struct {
 	FilePath    string
 	FileName    string
 	LineNumber  int
+	Environment string
 }
 
 type IssueManager interface {
@@ -43,6 +47,19 @@ func NewIssueManager(issueType string, annotation string) (IssueManager, error) 
 	default:
 		return nil, errors.New("Unsupported issue type. Use 'pending' or 'processed'")
 	}
+}
+
+func (issue *Issue) GenerateIssueTmplMarkdown(path string) ([]byte, error) {
+	buf := bytes.Buffer{}
+	issue.Environment = runtime.GOOS
+
+	tmpl, err := template.ParseFiles(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tmpl.Execute(&buf, issue)
+	return buf.Bytes(), err
 }
 
 func skipGitDir(name string) bool {

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -43,7 +43,7 @@ type GitConfigManager interface {
 	IsAuthorized() (bool, error)
 }
 
-func GetGitConfig(scm string) GitConfigManager {
+func NewGitManager(scm string) GitConfigManager {
 	switch scm {
 	default:
 		return &GitHubManager{}

--- a/pkg/scm/ignore.go
+++ b/pkg/scm/ignore.go
@@ -21,7 +21,10 @@ type IgnorePattern = regexp.Regexp
 @TODO add ! (not) operator support for ignoring specific files/directories.
 
 The ParseIgnorePatterns can handle most of the common patterns found in a gitignore
-file. However, there are scenarios where this function will fail to build proper regexps.
+file. However, there are scenarios where this function will fail to build proper expressions
+and cause the program to crash. There are large open source projects I have tested the program on
+that crash the program and we should resolve this immediately.
+
 Here is an example of some patterns that are not yet supported:
 
 1. Ignore files in a specific directory, but not its subdirectories:

--- a/pkg/scm/ignore.go
+++ b/pkg/scm/ignore.go
@@ -20,14 +20,13 @@ type IgnorePattern = regexp.Regexp
 /*
 @TODO add ! (not) operator support for ignoring specific files/directories.
 
-The ParseIgnorePatterns can handle most of the common patterns found in a gitignore
-file. However, there are scenarios where this function will fail to build proper expressions
-and cause the program to crash. There are large open source projects I have tested the program on
-that crash the program and we should resolve this immediately.
-
+The ParseIgnorePatterns func can handle most of the common patterns found in a gitignore file.
+However, there are scenarios where this function will fail to build proper expressions and
+cause the program to crash. I've tested on many open source projects and for some we cannot
+run the program at all. We should resolve this immediately.
 Here is an example of some patterns that are not yet supported:
 
-1. Ignore files in a specific directory, but not its subdirectories:
+1. Ignore files in a specific directory, but not its sub-directories:
 directory_to_ignore/*
 !directory_to_ignore/*
 
@@ -38,7 +37,7 @@ directory_to_ignore/*
 3. Ignore all files in a directory, including hidden files:
 directory_to_ignore/**
 !directory_to_ignore/
-!directory_to_ignore/*
+!directory_to_ignore
 */
 func ParseIgnorePatterns(r io.Reader) ([]IgnorePattern, error) {
 	regexps := make([]IgnorePattern, 0)

--- a/templates/issue.tmpl
+++ b/templates/issue.tmpl
@@ -1,0 +1,16 @@
+### Description
+
+{{ .Description }}
+
+### Location
+
+***File name:*** `{{ .FileName}}` ***Line number:*** `{{ .AnnotationLineNumber }}`
+
+### Environment
+
+{{ .Environment }}
+
+### Generated with :heart:
+
+created by [issue-summoner](https://github.com/AntoninoAdornetto/issue-summoner)
+

--- a/templates/issue.tmpl
+++ b/templates/issue.tmpl
@@ -4,7 +4,7 @@
 
 ### Location
 
-***File name:*** `{{ .FileName}}` ***Line number:*** `{{ .AnnotationLineNumber }}`
+***File name:*** `{{ .FileName}}` ***Line number:*** `{{ .LineNumber }}`
 
 ### Environment
 


### PR DESCRIPTION
# Features

- utilizing the `report` command, you can now scan source code for issue annotations and select which ones you would like to publish to GitHub. 
- reporting an issue will utilize the template library from go to format the markdown prior to publishing 

# Notes

- reporting an issue should update the annotation so that we can remove the comment at a later time. This will be implemented soon but is not part of the new version yet. 