### PR TITLE
Unable to open issue template file when reporting new issues

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/issue"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
+	"github.com/AntoninoAdornetto/issue-summoner/templates"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
@@ -88,10 +89,15 @@ platform.`,
 			ui.LogFatal(err.Error())
 		}
 
+		tmpl, err := templates.LoadIssueTemplate()
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
 		staged := make([]scm.Issue, 0)
 		for _, is := range issues {
 			if selections.Options[is.ID] {
-				md, err := is.GenerateIssueTmplMarkdown(issue_template_path)
+				md, err := is.ExecuteIssueTemplate(tmpl)
 				if err != nil {
 					ui.LogFatal(err.Error())
 				}

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -49,16 +49,10 @@ func NewIssueManager(issueType string, annotation string) (IssueManager, error) 
 	}
 }
 
-func (issue *Issue) GenerateIssueTmplMarkdown(path string) ([]byte, error) {
+func (issue *Issue) ExecuteIssueTemplate(tmpl *template.Template) ([]byte, error) {
 	buf := bytes.Buffer{}
 	issue.Environment = runtime.GOOS
-
-	tmpl, err := template.ParseFiles(path)
-	if err != nil {
-		return nil, err
-	}
-
-	err = tmpl.Execute(&buf, issue)
+	err := tmpl.Execute(&buf, issue)
 	return buf.Bytes(), err
 }
 

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -85,7 +85,7 @@ func WriteToken(token string, scm string) error {
 
 	switch scm {
 	default:
-		config["GitHub"] = ScmTokenConfig{
+		config[GH] = ScmTokenConfig{
 			AccessToken: token,
 		}
 	}

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,0 +1,23 @@
+/*
+Using embed will allow us to directly embed the contents of the issue.tmpl
+template file into a variable (issueTemplate). When the program is compiled,
+go can read the contents of the file. This process is exactly what we need
+to publish git issues from any directory in the file system. Additionally,
+the template file is small (4KB) and we only expect to have the 1 file.
+*/
+package templates
+
+import (
+	"embed"
+	"text/template"
+)
+
+var (
+	//go:embed issue.tmpl
+	issueTemplate embed.FS
+)
+
+func LoadIssueTemplate() (*template.Template, error) {
+	tmpl, err := template.New("issue.tmpl").ParseFS(issueTemplate, "issue.tmpl")
+	return tmpl, err
+}


### PR DESCRIPTION
## Overview 

After installing the program and wanting to `report` a new issue to a remote github repository, the program fails because it cannot find the `issue.tmpl` file. 

## Fixes

- use go's embed package to embed the contents of `issue.tmpl` into a variable at compile time. The size of the file is 4KB and I only expect to use just this one template for reporting issues. 