### PR TITLE
Prep work for reporting phase

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -94,22 +94,22 @@ platform.`,
 			ui.LogFatal(err.Error())
 		}
 
-		staged := make([]scm.Issue, 0)
+		stagedIssues := make([]scm.Issue, 0)
 		for _, is := range issues {
 			if selections.Options[is.ID] {
 				md, err := is.ExecuteIssueTemplate(tmpl)
 				if err != nil {
 					ui.LogFatal(err.Error())
 				}
-				staged = append(
-					staged,
+				stagedIssues = append(
+					stagedIssues,
 					scm.Issue{Title: is.Title, Body: string(md)},
 				)
 			}
 		}
 
 		gitManager := scm.NewGitManager(sourceCodeManager)
-		idChan := gitManager.ReportIssues(staged)
+		idChan := gitManager.Report(stagedIssues)
 
 		for id := range idChan {
 			/*

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -109,9 +109,21 @@ platform.`,
 		}
 
 		gitManager := scm.NewGitManager(sourceCodeManager)
-		err = gitManager.Report(staged, sourceCodeManager)
-		if err != nil {
-			ui.LogFatal(err.Error())
+		idChan := gitManager.ReportIssues(staged)
+
+		for id := range idChan {
+			/*
+			* @TODO Write the issue ID to it's corresponding comment
+			* The final piece to publishing an issue on a scm (Github, GitLab, BitBucket etc..)
+			* is writing the id to the source code file where we discovered the issue annotation.
+			* For example, if we have a source code file with a comment such as:
+			* // @TODO: fix bug
+			* We would want to append the id to the annotation. The result would be:
+			* // @TODO(1234): fix bug
+			* This allows the program to perform clean up work and remove the comment once the issue
+			* has been marked as resolved.
+			 */
+			fmt.Println("ID ", id)
 		}
 	},
 }

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"regexp"
 	"runtime"
-	"strings"
 	"text/template"
 )
 
@@ -54,10 +53,6 @@ func (issue *Issue) ExecuteIssueTemplate(tmpl *template.Template) ([]byte, error
 	issue.Environment = runtime.GOOS
 	err := tmpl.Execute(&buf, issue)
 	return buf.Bytes(), err
-}
-
-func skipGitDir(name string) bool {
-	return strings.Contains(name, ".git")
 }
 
 func skipIgnoreMatch(path string, patterns []regexp.Regexp) bool {

--- a/pkg/issue/pending.go
+++ b/pkg/issue/pending.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/lexer"
 )
@@ -17,15 +18,14 @@ type PendingIssue struct {
 
 func (pi *PendingIssue) Walk(root string, gitIgnore []regexp.Regexp) (int, error) {
 	n := 0
-	foundGitDir := false
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		if d.IsDir() {
-			if !foundGitDir && skipGitDir(d.Name()) {
-				foundGitDir = true
+			// @TODO Flag for Walking/Scanning hidden dirs? Revisit this thought
+			if strings.HasPrefix(d.Name(), ".") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -53,9 +53,9 @@ func (pi *PendingIssue) Scan(src []byte, path string) error {
 
 	/*
 	* @TODO remove file extension check when additional language support is added.
-	* The implementation has changed drastically and is now utilizing scanning/lexing
+	* The implementation has changed drastically and is now utilizing a scanning/lexing
 	* approach. I am starting out with languages that have adopted similar comment syntax
-	* to C since it's the most common. Once more support is added, we can remove this check
+	* to C, since it's the most common. Once more languages are added, we can remove this check
 	 */
 
 	if !lexer.IsAdoptedFromC(ext) {

--- a/pkg/lexer/c.go
+++ b/pkg/lexer/c.go
@@ -8,6 +8,7 @@ import (
 
 var allowed = []string{
 	".c",
+	".h",
 	".cpp",
 	".java",
 	".js",

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -27,6 +27,7 @@ type GitConfig struct {
 	Scm            string // GitHub || GitLab || BitBucket ...
 }
 
+// @TODO Change the name of scm.Issue struct. It conflicts with the struct in issue.go
 type Issue struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
@@ -39,8 +40,7 @@ type Issue struct {
 // ReadToken checks if there is an access token in ~/.config/issue-summoner/config.json
 type GitConfigManager interface {
 	Authorize() error
-	Report(issues []Issue, scm string) error
-	IsAuthorized() (bool, error)
+	Report(issues []Issue) <-chan int64
 }
 
 func NewGitManager(scm string) GitConfigManager {

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -22,6 +24,7 @@ const (
 	ACCEPT_JSON        = "application/json"
 	ACCEPT_VDN         = "application/vnd.github+json"
 	GITHUB_API_VERSION = "2022-11-28"
+	create_issue_error = "failed to create issue <%s> with status code: %d\terror: %s"
 )
 
 type GitHubManager struct{}
@@ -64,46 +67,96 @@ type createIssueResponse struct {
 	Title         string `json:"title"`
 }
 
-func createIssue(issue Issue, accessToken string) (createIssueResponse, error) {
+func createIssue(issue Issue) (createIssueResponse, error) {
 	var res createIssueResponse
 
-	repoName, err := RepoName()
+	payload, err := json.Marshal(issue)
 	if err != nil {
 		return res, err
 	}
 
-	userName, err := GlobalUserName()
+	body := bytes.NewBuffer(payload)
+	req, err := newIssueRequest(body)
 	if err != nil {
 		return res, err
 	}
 
-	paths := []string{"repos", userName, repoName, "issues"}
-	url, err := utils.BuildURL(GITHUB_BASE_URL, paths, nil)
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return res, err
 	}
 
-	body, err := json.Marshal(issue)
-	if err != nil {
-		return res, err
+	if resp.StatusCode != 201 {
+		return res, handleCreateIssueErr(data, resp.StatusCode, issue.Title)
 	}
 
-	headers := http.Header{}
-	headers.Add("Accept", ACCEPT_VDN)
-	headers.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	headers.Add("X-GitHub-Api-Version", GITHUB_API_VERSION)
-
-	resp, err := utils.SubmitPostRequest(url, bytes.NewReader(body), headers)
-	if err != nil {
-		return res, err
-	}
-
-	err = json.Unmarshal(resp, &res)
+	err = json.Unmarshal(data, &res)
 	if err != nil {
 		return res, err
 	}
 
 	return res, nil
+}
+
+type createIssueErrorResponse struct {
+	Message string `json:"message"`
+}
+
+func handleCreateIssueErr(data []byte, statusCode int, title string) error {
+	var res createIssueErrorResponse
+	var err error
+
+	err = json.Unmarshal(data, &res)
+	if err != nil {
+		return fmt.Errorf(create_issue_error, title, statusCode, err.Error())
+	}
+
+	return fmt.Errorf(create_issue_error, title, statusCode, res.Message)
+}
+
+var accessToken = ""
+
+func newIssueRequest(body io.Reader) (*http.Request, error) {
+	if accessToken == "" {
+		token, err := ReadAccessToken(GH)
+		if err != nil {
+			return nil, err
+		}
+		accessToken = token
+	}
+
+	repoName, err := RepoName()
+	if err != nil {
+		return nil, err
+	}
+
+	userName, err := GlobalUserName()
+	if err != nil {
+		return nil, err
+	}
+
+	uri, err := url.JoinPath(GITHUB_BASE_URL, "repos", userName, repoName, "issues")
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", uri, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Accept", ACCEPT_VDN)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	req.Header.Add("X-GitHub-Api-Version", GITHUB_API_VERSION)
+
+	return req, nil
 }
 
 // Authorize satisfies the GitManager interface. Each source code management
@@ -130,13 +183,6 @@ func (gh *GitHubManager) Authorize() error {
 	case err := <-errChan:
 		return err
 	}
-}
-
-// @TODO do we still need the IsAuthorized func?
-// there is a check in git.go that validates if the user
-// has an access token
-func (gh *GitHubManager) IsAuthorized() (bool, error) {
-	return CheckForAccess(GH)
 }
 
 func initDeviceFlow(vd chan requestDeviceVerificationResponse, ec chan error) {

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -111,9 +111,7 @@ type createIssueErrorResponse struct {
 
 func handleCreateIssueErr(data []byte, statusCode int, title string) error {
 	var res createIssueErrorResponse
-	var err error
-
-	err = json.Unmarshal(data, &res)
+	err := json.Unmarshal(data, &res)
 	if err != nil {
 		return fmt.Errorf(create_issue_error, title, statusCode, err.Error())
 	}


### PR DESCRIPTION
# Description 

The program can now report issues to GitHub, this is great but we still have some work left to do. After reporting an issue, the plan is to take the ID associated with the GitHub issue and write to the comment that the issue was extracted from. 

Let's use the below comment as an example and say that the user reports this as an issue to a GitHub repo.

```c
int main() {
  // @TODO do something useful in the main function
  return 0;
}
```

The goal is to append the ID returned from the `createIssue` request. The result would be:

```c
int main() {
  // @TODO(1234) do something useful in the main function
  return 0;
}
```

This would allow the program to perform clean up work and remove the entire comment once the issue has been marked as resolve. One of the benefits of building out a lexer/tokenizer is that I can utilize the line/column numbers of the comment and easily write to it and remove the comment. 

# Other fixes

- I wasn't planning on making a git ignore parser but there are some issues with the quick and fast solution I made to ignore certain files/directories. I will need to spend more time adjusting `ignore.go` but wanted to get some of the bigger features moving first. 
- The go routines I was using for reporting issues to github was not implemented properly and was failing to log the error messages that GitHub may return. 
- ignore hidden files when walking the project directory 