### PR TITLE
Lexer Modularity 

### DIFF
--- a/pkg/lexer/c.go
+++ b/pkg/lexer/c.go
@@ -1,7 +1,6 @@
 package lexer
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
 )
@@ -105,11 +104,11 @@ func (cl *CLexer) ParseCommentTokens(lex *Lexer, annotation []byte) ([]Comment, 
 	for i, token := range lex.Tokens {
 		switch token.TokenType {
 		case SINGLE_LINE_COMMENT:
-			comment := ParseSingleLineCommentToken(&token, annotation)
-			pushComment(&comment, &comments, lex.FileName, i)
+			comment := token.ParseSingleLineCommentToken(annotation, trimCommentC)
+			comment.Push(&comments, lex.FileName, i)
 		case MULTI_LINE_COMMENT:
-			comment := ParseMultiLineCommentToken(&token, annotation)
-			pushComment(&comment, &comments, lex.FileName, i)
+			comment := token.ParseMultiLineCommentToken(annotation, trimCommentC)
+			comment.Push(&comments, lex.FileName, i)
 		default:
 			continue
 		}
@@ -117,59 +116,12 @@ func (cl *CLexer) ParseCommentTokens(lex *Lexer, annotation []byte) ([]Comment, 
 	return comments, nil
 }
 
-func ParseSingleLineCommentToken(token *Token, annotation []byte) Comment {
-	loc := findAnnotationLocations(annotation, token.Lexeme)
-	if loc == nil {
-		return Comment{}
-	}
-	end := loc[1]
-	title := bytes.TrimFunc(token.Lexeme[end:], trimComment)
-	return Comment{
-		Title:  title,
-		Source: token.Lexeme,
-	}
-}
-
-func ParseMultiLineCommentToken(token *Token, annotation []byte) Comment {
-	loc := findAnnotationLocations(annotation, token.Lexeme)
-	if loc == nil {
-		return Comment{}
-	}
-	end := loc[1]
-	content := bytes.TrimFunc(token.Lexeme[end:], trimComment)
-	newLines := bytes.Split(content, []byte("\n"))
-
-	comment := Comment{
-		Title:  bytes.TrimFunc(newLines[0], trimComment),
-		Source: token.Lexeme,
-	}
-
-	for i := 1; i < len(newLines); i++ {
-		comment.Description = append(
-			comment.Description,
-			bytes.TrimLeftFunc(newLines[i], trimComment)...)
-
-		if i != len(newLines)-1 {
-			comment.Description = append(comment.Description, ' ')
-		}
-	}
-
-	return comment
-}
-
-func pushComment(comment *Comment, comments *[]Comment, fileName string, index int) {
-	if comment.Validate() {
-		comment.Prepare(fileName, index)
-		*comments = append(*comments, *comment)
-	}
-}
-
 func findAnnotationLocations(annotation []byte, commentText []byte) []int {
 	re := regexp.MustCompile(string(annotation))
 	return re.FindIndex(commentText)
 }
 
-func trimComment(r rune) bool {
+func trimCommentC(r rune) bool {
 	switch r {
 	case rune(WHITESPACE), rune(TAB), rune(NEWLINE), rune(ASTERISK), rune(FORWARD_SLASH):
 		return true

--- a/pkg/lexer/comment.go
+++ b/pkg/lexer/comment.go
@@ -16,3 +16,10 @@ func (c *Comment) Prepare(fileName string, index int) {
 func (c *Comment) Validate() bool {
 	return len(c.Source) > 0
 }
+
+func (c *Comment) Push(comments *[]Comment, fileName string, tokenIndex int) {
+	if c.Validate() {
+		c.Prepare(fileName, tokenIndex)
+		*comments = append(*comments, *c)
+	}
+}

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -9,6 +9,19 @@ const (
 	EOF
 )
 
+var (
+	ASTERISK       byte = '*'
+	BACK_TICK      byte = '`'
+	BACKWARD_SLASH byte = '\\'
+	FORWARD_SLASH  byte = '/'
+	HASH           byte = '#'
+	QUOTE          byte = '\''
+	DOUBLE_QUOTE   byte = '"'
+	NEWLINE        byte = '\n'
+	TAB            byte = '\t'
+	WHITESPACE     byte = ' '
+)
+
 type Token struct {
 	TokenType      TokenType
 	Lexeme         []byte

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -1,5 +1,7 @@
 package lexer
 
+import "bytes"
+
 type TokenType = int
 
 const (
@@ -28,4 +30,44 @@ type Token struct {
 	Line           int
 	StartByteIndex int
 	EndByteIndex   int
+}
+
+func (t *Token) ParseSingleLineCommentToken(annotation []byte, trim func(r rune) bool) Comment {
+	loc := findAnnotationLocations(annotation, t.Lexeme)
+	if loc == nil {
+		return Comment{}
+	}
+	end := loc[1]
+	title := bytes.TrimFunc(t.Lexeme[end:], trim)
+	return Comment{
+		Title:  title,
+		Source: t.Lexeme,
+	}
+}
+
+func (t *Token) ParseMultiLineCommentToken(annotation []byte, trim func(r rune) bool) Comment {
+	loc := findAnnotationLocations(annotation, t.Lexeme)
+	if loc == nil {
+		return Comment{}
+	}
+	end := loc[1]
+	content := bytes.TrimFunc(t.Lexeme[end:], trim)
+	newLines := bytes.Split(content, []byte("\n"))
+
+	comment := Comment{
+		Title:  bytes.TrimFunc(newLines[0], trim),
+		Source: t.Lexeme,
+	}
+
+	for i := 1; i < len(newLines); i++ {
+		comment.Description = append(
+			comment.Description,
+			bytes.TrimLeftFunc(newLines[i], trim)...)
+
+		if i != len(newLines)-1 {
+			comment.Description = append(comment.Description, ' ')
+		}
+	}
+
+	return comment
 }

--- a/pkg/scm/ignore.go
+++ b/pkg/scm/ignore.go
@@ -17,6 +17,29 @@ import (
 
 type IgnorePattern = regexp.Regexp
 
+/*
+@TODO .gitignore path validation rules are broken
+Throughout some testing on large open source projects, I have found the effectiveness of-
+ignoring paths largely unsuccessful. There are edge cases we need to bake into these functions:
+
+1. (!) Prefix to negate patterns. Matching files excluded by previous patters will become included again.
+
+2. (/) Separator placement. Beginning, middle (or both) means the path pattern is relative to the directory level
+of the gitignore file. If the separator is at the end, the pattern should match directories or files
+
+3. (*) Asterisk matches anything except a slash.
+
+4. (?) Matches any one character except "/"
+
+5. [a-zA-Z] Range notation can be used to match one of the characters in a range
+
+6. (**) Leading/Trailing Double Asterisks
+
+7. Sub directories may contain their own gitignore file. Account for this.
+
+This initial implementation was quick and dirty and it worked for small projects. However, it is now causing issues
+and may lead to some files/directories not being scanned at all or scanning files/dirs that shouldn't be scanned.
+*/
 func ParseIgnorePatterns(r io.Reader) ([]IgnorePattern, error) {
 	regexps := make([]IgnorePattern, 0)
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
# Description

In preparation for adding new lexers (python is up next) I found a need to move some of the lexing functionality around so that any new implementation that satisfies the LexingManager interface can easily create and parse comment tokens. 

# TODO's 

The ignore path logic needs to be altered quite a bit. There are files and directories that are getting ignored when they shouldn't be and there are scenarios where files and directories are getting ignored when they shouldn't be. I've used the new report command to create a github issue for this : ) 