### PR TITLE
enhance error handling and clean up auth funcs - git.go & github.go

### DIFF
--- a/cmd/authorize.go
+++ b/cmd/authorize.go
@@ -51,12 +51,12 @@ var authorizeCmd = &cobra.Command{
 			)
 		}
 
-		hasAccess, err := scm.CheckForAccess(sourceCodeManager)
+		accessToken, err := scm.ReadAccessToken(sourceCodeManager)
 		if err != nil && !os.IsNotExist(err) {
 			ui.LogFatal(err.Error())
 		}
 
-		if hasAccess {
+		if accessToken != "" {
 			fmt.Println(
 				ui.PrimaryTextStyle.Render(
 					fmt.Sprintf(
@@ -88,7 +88,11 @@ var authorizeCmd = &cobra.Command{
 			}
 		}()
 
-		gitManager := scm.NewGitManager(sourceCodeManager)
+		gitManager, err := scm.NewGitManager(sourceCodeManager, "", "")
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
 		err = gitManager.Authorize()
 		if err != nil {
 			if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {

--- a/cmd/authorize.go
+++ b/cmd/authorize.go
@@ -16,7 +16,7 @@ import (
 
 // We only support GitHub, at the moment, but eventually I want to support all that are contained
 // in the `allowedPlatforms` slice.
-var allowedPlatforms = []string{scm.GH, scm.GL, scm.BB}
+var allowedPlatforms = []string{scm.GITHUB, scm.GITLAB, scm.BITBUCKET}
 
 // authorizeCmd represents the authorize command
 var authorizeCmd = &cobra.Command{
@@ -112,5 +112,5 @@ var authorizeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(authorizeCmd)
-	authorizeCmd.Flags().StringP(flag_scm, shortflag_scm, scm.GH, flag_desc_scm)
+	authorizeCmd.Flags().StringP(flag_scm, shortflag_scm, scm.GITHUB, flag_desc_scm)
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -30,7 +30,7 @@ const (
 	shortflag_verbose    = "v"
 	shortflag_annotation = "a"
 	flag_desc_path       = "the path to your local git repository"
-	flag_desc_scm        = "The source code management platform you would like to use. Example: GitHub or GitLab"
+	flag_desc_scm        = "The source code management platform you would like to use. Such as, github, gitlab, or bitbucket"
 	flag_desc_gignore    = "path to gitignore file"
 	flag_desc_mode       = "'processed' is for issues that have already been pushed to a scm. 'pending' is for issues that have not yet been published"
 	flag_desc_verbose    = "log detailed information about each issue annotation that is located during the scan"

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -4,8 +4,10 @@ Copyright © 2024 AntoninoAdornetto
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/issue"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
@@ -32,17 +34,15 @@ platform.`,
 			ui.LogFatal(err.Error())
 		}
 
-		isAuthorized, err := scm.CheckForAccess(sourceCodeManager)
+		_, err = scm.ReadAccessToken(sourceCodeManager)
 		if err != nil {
 			if os.IsNotExist(err) {
-				ui.LogFatal(err_unauthorized)
+				ui.LogFatal(
+					"configuration file does not exist. please run <issue-summoner authorize> or see <issue-summoner authorize --help>",
+				)
 			} else {
 				ui.LogFatal(err.Error())
 			}
-		}
-
-		if !isAuthorized {
-			ui.LogFatal(err_unauthorized)
 		}
 
 		issueManager, err := issue.NewIssueManager(issue.PENDING_ISSUE, annotation)
@@ -94,7 +94,7 @@ platform.`,
 			ui.LogFatal(err.Error())
 		}
 
-		stagedIssues := make([]scm.Issue, 0)
+		stagedIssues := make([]scm.GitIssue, 0)
 		for _, is := range issues {
 			if selections.Options[is.ID] {
 				md, err := is.ExecuteIssueTemplate(tmpl)
@@ -103,7 +103,7 @@ platform.`,
 				}
 				stagedIssues = append(
 					stagedIssues,
-					scm.Issue{Title: is.Title, Body: string(md)},
+					scm.GitIssue{Title: is.Title, Body: string(md)},
 				)
 			}
 		}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -144,5 +144,5 @@ func init() {
 	reportCmd.Flags().StringP(flag_path, shortflag_path, "", flag_desc_path)
 	reportCmd.Flags().StringP(flag_gignore, shortflag_gignore, "", flag_desc_gignore)
 	reportCmd.Flags().StringP(flag_annotation, shortflag_annotation, "@TODO", flag_desc_annotation)
-	reportCmd.Flags().StringP(flag_scm, shortflag_scm, scm.GH, flag_desc_scm)
+	reportCmd.Flags().StringP(flag_scm, shortflag_scm, scm.GITHUB, flag_desc_scm)
 }

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -116,6 +116,10 @@ platform.`,
 		}
 
 		userName, repoName, err := scm.ExtractUserRepoName(out.Bytes())
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
 		gitManager, err := scm.NewGitManager(sourceCodeManager, userName, repoName)
 		if err != nil {
 			ui.LogFatal(err.Error())

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -108,9 +108,20 @@ platform.`,
 			}
 		}
 
-		gitManager := scm.NewGitManager(sourceCodeManager)
-		idChan := gitManager.Report(stagedIssues)
+		out := bytes.Buffer{}
+		remoteCmd := exec.Command("git", "remote", "-v")
+		remoteCmd.Stdout = &out
+		if err := remoteCmd.Run(); err != nil {
+			ui.LogFatal(err.Error())
+		}
 
+		userName, repoName, err := scm.ExtractUserRepoName(out.Bytes())
+		gitManager, err := scm.NewGitManager(sourceCodeManager, userName, repoName)
+		if err != nil {
+			ui.LogFatal(err.Error())
+		}
+
+		idChan := gitManager.Report(stagedIssues)
 		for id := range idChan {
 			/*
 			* @TODO Write the issue ID to it's corresponding comment

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -1,13 +1,13 @@
 package scm
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
-	"strings"
 )
 
 const (
@@ -16,37 +16,31 @@ const (
 	BITBUCKET = "bitbucket"
 )
 
-// @TODO can GlobalUserName and RepoName functions be deleted?
-// We are now using the device flow and the mentioned functions could be useless since
-// we are creating an access token for the user after they authorize the application.
-
-type GitConfig struct {
-	UserName       string
-	RepositoryName string
-	Token          string
-	Scm            string // GitHub || GitLab || BitBucket ...
-}
-
-// @TODO Change the name of scm.Issue struct. It conflicts with the struct in issue.go
-type Issue struct {
+type GitIssue struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
 }
 
-// GitConfigManager interface allows us to have different adapters for each
-// source code management system that we would like to use. We can have different
-// implementations for GitHub, GitLab, BitBucket and so on.
-// Authorize creates an access token with scopes that will allow us to read/write issues
-// ReadToken checks if there is an access token in ~/.config/issue-summoner/config.json
+// GitConfigManager provides flexibility to have different implementations
+// of Authorize and Report for each source code management platform supported
 type GitConfigManager interface {
 	Authorize() error
-	Report(issues []Issue) <-chan int64
+	Report(issues []GitIssue) <-chan int64
 }
 
-func NewGitManager(scm string) GitConfigManager {
+// @TODO add other source code management structs to NewGitManager once their implementations are created
+func NewGitManager(scm, userName, repoName string) (GitConfigManager, error) {
 	switch scm {
+	case GITHUB:
+		return &GitHubManager{repoName: repoName, userName: userName}, nil
 	default:
-		return &GitHubManager{}
+		return nil, fmt.Errorf(
+			"expected to receive scm with value of %s, %s, or %s but got %s",
+			GITHUB,
+			GITLAB,
+			BITBUCKET,
+			scm,
+		)
 	}
 }
 
@@ -61,28 +55,29 @@ type IssueSummonerConfig = map[string]ScmTokenConfig
 // This will be used to authorize future requests for reporting issues.
 func WriteToken(token string, scm string) error {
 	config := make(map[string]ScmTokenConfig)
-
-	usr, err := user.Current()
+	path, err := getConfigDirPath()
 	if err != nil {
 		return err
 	}
-
-	home := usr.HomeDir
-	path := filepath.Join(home, ".config", "issue-summoner")
 
 	err = os.MkdirAll(path, 0755)
 	if err != nil {
 		return err
 	}
 
-	configFile := filepath.Join(path, "config.json")
-	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0666)
+	configFilePath, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}
 
 	defer file.Close()
 
+	// @TODO add remaining source code management platforms once other adapters are implemented
 	switch scm {
 	default:
 		config[GITHUB] = ScmTokenConfig{
@@ -102,53 +97,14 @@ func WriteToken(token string, scm string) error {
 	return nil
 }
 
-// @TODO refactor WriteToken & CheckForAccess functions.
-// There is some DRY code in the two functions that I would like to refactor.
-// Specifically for getting the current directory, home dir and joining the paths
-// for the configuration file.
-func CheckForAccess(scm string) (bool, error) {
-	config := make(map[string]ScmTokenConfig)
-	authorized := false
-
-	usr, err := user.Current()
-	if err != nil {
-		return authorized, err
-	}
-
-	home := usr.HomeDir
-	configFile := filepath.Join(home, ".config", "issue-summoner", "config.json")
-
-	file, err := os.OpenFile(configFile, os.O_RDONLY, 0666)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return authorized, err
-		} else {
-			return authorized, errors.New("Error opening file")
-		}
-	}
-
-	defer file.Close()
-
-	decoder := json.NewDecoder(file)
-	if err := decoder.Decode(&config); err != nil {
-		return authorized, errors.New("Error decoding config file")
-	}
-
-	return config[scm].AccessToken != "", nil
-}
-
 func ReadAccessToken(scm string) (string, error) {
 	config := make(map[string]ScmTokenConfig)
-
-	usr, err := user.Current()
+	path, err := getConfigFilePath()
 	if err != nil {
 		return "", err
 	}
 
-	home := usr.HomeDir
-	configFile := filepath.Join(home, ".config", "issue-summoner", "config.json")
-
-	file, err := os.OpenFile(configFile, os.O_RDONLY, 0666)
+	file, err := os.OpenFile(path, os.O_RDONLY, 0666)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", err
@@ -220,62 +176,20 @@ func extractFromSSH(url []byte) (string, string) {
 	return string(userName), string(bytes.TrimSuffix(repoName, []byte(".git")))
 }
 
-// GlobalUserName uses the **git config** command to retrieve the global
-// configuration options. Specifically, the user.name option. The userName is
-// read and set onto the reciever's (GitConfig) UserName property. This will be used
-func GlobalUserName() (string, error) {
-	var out strings.Builder
-	cmd := exec.Command("git", "config", "--global", "user.name")
-	cmd.Stdout = &out
-
-	err := cmd.Run()
+func getConfigDirPath() (string, error) {
+	usr, err := user.Current()
 	if err != nil {
 		return "", err
 	}
 
-	userName := strings.TrimSpace(out.String())
-	if userName == "" {
-		return "", errors.New("global userName option not set. See man git config for more details")
-	}
-
-	return userName, nil
+	homeDir := usr.HomeDir
+	return filepath.Join(homeDir, ".config", "issue-summoner"), nil
 }
 
-// @TODO write unit test for RepoName/extractRepoName function.
-func RepoName() (string, error) {
-	var out strings.Builder
-	cmd := exec.Command("git", "remote", "-v")
-	cmd.Stdout = &out
-
-	err := cmd.Run()
+func getConfigFilePath() (string, error) {
+	configDir, err := getConfigDirPath()
 	if err != nil {
 		return "", err
 	}
-
-	repoName := extractRepoName(out.String())
-	if repoName == "" {
-		return "", errors.New("Failed to get repo name")
-	}
-
-	return repoName, nil
-}
-
-// extractRepoName takes the output from the `git remote -v` command as input (origins) and outputs the repository name.
-// The function can handle both ssh and https origins.
-// Git does not offer a command that outputs the repository name directly
-func extractRepoName(origins string) string {
-	for _, line := range strings.Split(origins, "\n") {
-		if strings.Contains(line, "(push)") {
-			fields := strings.Fields(line)
-			if len(fields) >= 2 {
-				repoURL := fields[1]
-				parts := strings.Split(repoURL, "/")
-				if len(parts) > 1 {
-					repo := strings.TrimSuffix(parts[len(parts)-1], ".git")
-					return repo
-				}
-			}
-		}
-	}
-	return ""
+	return filepath.Join(configDir, "config.json"), nil
 }

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -173,7 +173,7 @@ func ReadAccessToken(scm string) (string, error) {
 }
 
 // ExtractUserRepoName takes the output from <git remote --verbose> command
-// as input and attempts to extract the user name and repository name. (HTTPS || SSH url)
+// as input and attempts to extract the user name and repository name from out
 func ExtractUserRepoName(out []byte) (string, string, error) {
 	if len(out) == 0 {
 		return "", "", errors.New(

--- a/pkg/scm/git.go
+++ b/pkg/scm/git.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	GH = "github"
-	GL = "gitlab"
-	BB = "bitbucket"
+	GITHUB    = "github"
+	GITLAB    = "gitlab"
+	BITBUCKET = "bitbucket"
 )
 
 // @TODO can GlobalUserName and RepoName functions be deleted?
@@ -85,7 +85,7 @@ func WriteToken(token string, scm string) error {
 
 	switch scm {
 	default:
-		config[GH] = ScmTokenConfig{
+		config[GITHUB] = ScmTokenConfig{
 			AccessToken: token,
 		}
 	}

--- a/pkg/scm/git_test.go
+++ b/pkg/scm/git_test.go
@@ -15,6 +15,20 @@ const (
 	`
 )
 
+// should create a new GitHubManager struct
+func TestNewGitManagerGitHub(t *testing.T) {
+	gm, err := scm.NewGitManager(scm.GITHUB, "AntoninoAdornetto", "issue-summoner")
+	require.NoError(t, err)
+	require.IsType(t, &scm.GitHubManager{}, gm)
+}
+
+// should return an error when provided an unsupported source code management platform
+func TestNewGitManagerUnsupported(t *testing.T) {
+	gm, err := scm.NewGitManager("unsupported", "AntoninoAdornetto", "issue-summoner")
+	require.Error(t, err)
+	require.Empty(t, gm)
+}
+
 // should return the username and repo name when provided output
 // from the git remote command that contains an https url
 func TestExtractUserRepoNameHTTPS(t *testing.T) {

--- a/pkg/scm/git_test.go
+++ b/pkg/scm/git_test.go
@@ -1,0 +1,55 @@
+package scm_test
+
+import (
+	"testing"
+
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ssh_remote_output = `origin	git@github.com:AntoninoAdornetto/issue-summoner.git (fetch)
+	origin	git@github.com:AntoninoAdornetto/issue-summoner.git (push)`
+	https_remote_output = `origin https://github.com/AntoninoAdornetto/issue-summoner.git (fetch)
+  origin https://github.com/AntoninoAdornetto/issue-summoner.git (push)
+	`
+)
+
+// should return the username and repo name when provided output
+// from the git remote command that contains an https url
+func TestExtractUserRepoNameHTTPS(t *testing.T) {
+	expectedUser, expectedRepo := "AntoninoAdornetto", "issue-summoner"
+	actualUser, actualRepo, err := scm.ExtractUserRepoName([]byte(https_remote_output))
+	require.NoError(t, err)
+	require.Equal(t, expectedRepo, actualRepo)
+	require.Equal(t, expectedUser, actualUser)
+}
+
+// should return the username and repo name when provided output
+// from the git remote command that contains an ssh url
+func TestExtractUserRepoNameSSH(t *testing.T) {
+	expectedUser, expectedRepo := "AntoninoAdornetto", "issue-summoner"
+	actualUser, actualRepo, err := scm.ExtractUserRepoName([]byte(ssh_remote_output))
+	require.NoError(t, err)
+	require.Equal(t, expectedRepo, actualRepo)
+	require.Equal(t, expectedUser, actualUser)
+}
+
+// should return empty user and repo name when provided empty byte slice as input
+func TestExtractUserRepoNameNoOutput(t *testing.T) {
+	userName, repoName, err := scm.ExtractUserRepoName([]byte{})
+	require.Empty(t, userName)
+	require.Empty(t, repoName)
+	require.Error(t, err)
+}
+
+// should return empty user and repo name when provided unexpected output, such
+// as a url that is neither https or ssh format
+func TestExtractUserRepoNameUnknownProtocol(t *testing.T) {
+	userName, repoName, err := scm.ExtractUserRepoName(
+		[]byte("origin unknown.protocolformaturl, (push)"),
+	)
+	require.Empty(t, userName)
+	require.Empty(t, repoName)
+	require.Error(t, err)
+}

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -27,7 +27,10 @@ const (
 	create_issue_error = "failed to create issue <%s> with status code: %d\terror: %s"
 )
 
-type GitHubManager struct{}
+type GitHubManager struct {
+	repoName string
+	userName string
+}
 
 func (gh *GitHubManager) Report(issues []Issue) <-chan int64 {
 	idChan := make(chan int64)
@@ -130,17 +133,7 @@ func newIssueRequest(body io.Reader) (*http.Request, error) {
 		accessToken = token
 	}
 
-	repoName, err := RepoName()
-	if err != nil {
-		return nil, err
-	}
-
-	userName, err := GlobalUserName()
-	if err != nil {
-		return nil, err
-	}
-
-	uri, err := url.JoinPath(GITHUB_BASE_URL, "repos", userName, repoName, "issues")
+	uri, err := url.JoinPath(GITHUB_BASE_URL, "repos", gh.userName, gh.repoName, "issues")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -126,7 +126,7 @@ var accessToken = ""
 
 func newIssueRequest(body io.Reader) (*http.Request, error) {
 	if accessToken == "" {
-		token, err := ReadAccessToken(GH)
+		token, err := ReadAccessToken(GITHUB)
 		if err != nil {
 			return nil, err
 		}
@@ -170,7 +170,7 @@ func (gh *GitHubManager) Authorize() error {
 
 	select {
 	case token := <-tokenChan:
-		return WriteToken(token.AccessToken, GH)
+		return WriteToken(token.AccessToken, GITHUB)
 	case err := <-errChan:
 		return err
 	}

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -176,6 +176,25 @@ func (gh *GitHubManager) Authorize() error {
 	}
 }
 
+/*
+@TODO user code is not printed when opening browser in same workspace as issue summoner process
+When executing <issue-summoner authorize>, without my default browser being open already, the
+user code is never printed to the terminal for me to copy and paste into githubs device authorization
+page. However, if I have my default browser open in a workspace where the issue summoner process is not running,
+I can see the user code is printed to the terminal just fine. I have a feeling this may be a simple fix where
+I just need to adjust the way I am utilizing go routines. Will investigate further.
+
+Environment Notes:
+This needs to be tested on other environments and most importantly, different tiling window managers.
+I am reporting this issue from Arch, btw, while using hyprland as my window manager.
+
+Expected Behavior: executing <issue-summoner authorize> should open the default browser and print the usercode
+to the terminal regardless if the browser is open already or if the browser opens in the same workspace as the
+issue-summoner process.
+
+Actual Behavior: executing <issue-summoner authorize> opens the default browser but fails to print the usercode
+to the terminal.
+*/
 func initDeviceFlow(vd chan requestDeviceVerificationResponse, ec chan error) {
 	resp, err := requestDeviceVerification()
 	if err != nil {

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -32,15 +32,15 @@ type GitHubManager struct {
 	userName string
 }
 
-func (gh *GitHubManager) Report(issues []Issue) <-chan int64 {
+func (gh *GitHubManager) Report(issues []GitIssue) <-chan int64 {
 	idChan := make(chan int64)
 	wg := sync.WaitGroup{}
 	wg.Add(len(issues))
 
 	for _, issue := range issues {
-		go func(is Issue) {
+		go func(is GitIssue) {
 			defer wg.Done()
-			resp, err := createIssue(is)
+			resp, err := gh.createIssue(is)
 			if err != nil {
 				fmt.Println(err.Error())
 				return
@@ -70,7 +70,7 @@ type createIssueResponse struct {
 	Title         string `json:"title"`
 }
 
-func createIssue(issue Issue) (createIssueResponse, error) {
+func (gh *GitHubManager) createIssue(issue GitIssue) (createIssueResponse, error) {
 	var res createIssueResponse
 
 	payload, err := json.Marshal(issue)
@@ -79,7 +79,7 @@ func createIssue(issue Issue) (createIssueResponse, error) {
 	}
 
 	body := bytes.NewBuffer(payload)
-	req, err := newIssueRequest(body)
+	req, err := gh.newIssueRequest(body)
 	if err != nil {
 		return res, err
 	}
@@ -124,7 +124,7 @@ func handleCreateIssueErr(data []byte, statusCode int, title string) error {
 
 var accessToken = ""
 
-func newIssueRequest(body io.Reader) (*http.Request, error) {
+func (gh *GitHubManager) newIssueRequest(body io.Reader) (*http.Request, error) {
 	if accessToken == "" {
 		token, err := ReadAccessToken(GITHUB)
 		if err != nil {

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -24,7 +24,8 @@ const (
 	ACCEPT_JSON        = "application/json"
 	ACCEPT_VDN         = "application/vnd.github+json"
 	GITHUB_API_VERSION = "2022-11-28"
-	create_issue_error = "failed to create issue <%s> with status code: %d\terror: %s"
+	err_create_issue   = "failed to create issue <%s> with status code: %d\terror: %s"
+	err_not_found      = "failed to create issue <%s> with status code: %d\terror: unable to find repo. please check your remote url via <git remote -v>"
 )
 
 type GitHubManager struct {
@@ -116,10 +117,14 @@ func handleCreateIssueErr(data []byte, statusCode int, title string) error {
 	var res createIssueErrorResponse
 	err := json.Unmarshal(data, &res)
 	if err != nil {
-		return fmt.Errorf(create_issue_error, title, statusCode, err.Error())
+		return fmt.Errorf(err_create_issue, title, statusCode, err.Error())
 	}
 
-	return fmt.Errorf(create_issue_error, title, statusCode, res.Message)
+	if statusCode == 404 {
+		return fmt.Errorf(err_not_found, title, statusCode)
+	}
+
+	return fmt.Errorf(err_create_issue, title, statusCode, res.Message)
 }
 
 var accessToken = ""


### PR DESCRIPTION
# Description

- extract git user name and repo name from `git remote --verbose` command versus global git config. Using global config  leaves room for error where the user name may not match the user name on a remote url. 
- remove unneeded functions from `git.go` and reduce dry code for getting the configuration file and paths
- add unit tests for user name and repo name extraction functions