### PR TITLE
Call issue summoner from sub directories

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
 	"github.com/AntoninoAdornetto/issue-summoner/pkg/ui"
 	"github.com/spf13/cobra"
 )
@@ -52,5 +53,10 @@ func handleCommonFlags(cmd *cobra.Command) (annotation string, path string) {
 		path = wd
 	}
 
-	return annotation, path
+	repo, err := scm.FindRepository(path)
+	if err != nil {
+		ui.LogFatal(err.Error())
+	}
+
+	return annotation, repo.WorkTree
 }

--- a/pkg/scm/repository.go
+++ b/pkg/scm/repository.go
@@ -1,0 +1,34 @@
+package scm
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+type Repository struct {
+	WorkTree string
+	Dir      string
+}
+
+func NewRepository(path string) *Repository {
+	return &Repository{
+		WorkTree: path,
+		Dir:      path + "/.git",
+	}
+}
+
+func FindRepository(wd string) (*Repository, error) {
+	if wd == "/" {
+		return nil, errors.New("expected to find a local git repo but found none.")
+	}
+
+	if _, err := os.Stat(filepath.Join(wd, ".git")); err != nil {
+		if os.IsNotExist(err) {
+			return FindRepository(filepath.Join(wd, "../"))
+		}
+		return nil, err
+	}
+
+	return NewRepository(wd), nil
+}

--- a/pkg/scm/repository_test.go
+++ b/pkg/scm/repository_test.go
@@ -1,0 +1,38 @@
+package scm_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/AntoninoAdornetto/issue-summoner/pkg/scm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRepository(t *testing.T) {
+	path := "/home/user/gitproject"
+	expectedWorkTree := path
+	expectedDir := path + "/.git"
+
+	repo := scm.NewRepository(path)
+	require.Equal(t, expectedWorkTree, repo.WorkTree)
+	require.Equal(t, expectedDir, repo.Dir)
+}
+
+func TestFindRepoSuccess(t *testing.T) {
+	wd, err := filepath.Abs("../../testdata/exclude/")
+	require.NoError(t, err)
+	repo, err := scm.FindRepository(wd)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	baseWorkTree := filepath.Base(repo.WorkTree)
+	baseDir := filepath.Base(repo.Dir)
+	require.Equal(t, "issue-summoner", baseWorkTree)
+	require.Equal(t, ".git", baseDir)
+}
+
+func TestFindRepoRootError(t *testing.T) {
+	wd := "/"
+	repo, err := scm.FindRepository(wd)
+	require.Error(t, err)
+	require.Nil(t, repo)
+}


### PR DESCRIPTION
# Changes

commands such as `scan` and `report` will need the path to your working tree. This means that if `issue summoner scan` is called from a sub directory, the program will not properly scan source files for comments. The changes in this pull request was to create a simple function that will recursively travel up the working directory until a `.git/` dir is located. The base case to exit is the root path.  