### PR TITLE
Fix: missing config file

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -91,5 +91,5 @@ func getConfigFile() (*os.File, error) {
 		return nil, err
 	}
 
-	return os.OpenFile(filepath.Join(path, "config.json"), os.O_RDWR, 0666)
+	return os.OpenFile(filepath.Join(path, "config.json"), os.O_RDWR|os.O_CREATE, 0666)
 }


### PR DESCRIPTION
The issue summoner JSON configuration file was missing a bit flag to create the file, if it doesn't exist already. 