### PR TITLE
Chore/relative annotation path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22.6"
+          go-version: "1.23.1"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22.6"
+          go-version: "1.23.1"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -143,6 +143,11 @@ print details about the issues, such as the description and location of the issu
 				)
 
 				fmt.Println(
+					ui.AccentTextStyle.Render("Path: "),
+					ui.PrimaryTextStyle.Render(iss.FilePath),
+				)
+
+				fmt.Println(
 					ui.AccentTextStyle.Render("Title: "),
 					ui.PrimaryTextStyle.Render(iss.Title),
 				)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AntoninoAdornetto/issue-summoner
 
-go 1.22.6
+go 1.23.1
 
 require (
 	github.com/AntoninoAdornetto/go-gitignore v0.1.5

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -68,6 +68,7 @@ type IssueManager struct {
 	Annotation  []byte
 	currentBase string
 	currentPath string
+	root        string
 	mode        IssueMode
 	os          string
 	template    *template.Template
@@ -125,10 +126,15 @@ func NewIssueManager(annotation []byte, mode IssueMode) (*IssueManager, error) {
 func (mngr *IssueManager) appendIssue(comment *lexer.Comment) error {
 	id := fmt.Sprintf("%s-%d:%d", mngr.currentPath, comment.TokenStartIndex, comment.TokenEndIndex)
 
+	rel, err := filepath.Rel(mngr.root, mngr.currentPath)
+	if err != nil {
+		return err
+	}
+
 	issue := Issue{
 		Description: comment.Description,
 		FileName:    mngr.currentBase,
-		FilePath:    mngr.currentPath,
+		FilePath:    rel,
 		ID:          id,
 		LineNumber:  comment.LineNumber,
 		OS:          mngr.os,
@@ -158,6 +164,7 @@ func (mngr *IssueManager) Walk(root string) error {
 		return err
 	}
 
+	mngr.root = root
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/issue/template.go
+++ b/pkg/issue/template.go
@@ -14,16 +14,18 @@ var (
 
 ### Location
 
-***File name:*** {{ .FileName }} ***Line number:*** {{ .LineNumber }}
+- ***File name:*** ` + "`" + `{{ .FileName }}` + "`" + `
+- ***Path:*** ` + "`" + `{{ .FilePath }}` + "`" + `
+- ***Line number:*** ` + "`" + `{{ .LineNumber }}` + "`" + `
 
 ### Environment
 
-{{ .OS }}
+- ` + "`" + `{{ .OS }}` + "`" + `
 
 ### Generated with :heart:
 
-created by [issue-summoner](https://github.com/AntoninoAdornetto/issue-summoner)
-	`
+- created by [issue-summoner](https://github.com/AntoninoAdornetto/issue-summoner)
+`
 )
 
 func generateIssueTemplate() (*template.Template, error) {


### PR DESCRIPTION
# Changes

Set and display the relative path of where issue annotations were located during a scan or report invocation. This will help user's locate the files easier, especially in the scenario where projects may contain multiple files with the same name but reside in different sub directories. 

The path is relative from the project root to the file in which the issue annotation(s) were found. 