### PR TITLE
Fix concurrent map writes when purging code comments

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -52,7 +52,7 @@ func NewGitManager(sch sourceCodeHost, repo *Repository) (GitManager, error) {
 	case Gitlab:
 		return nil, errors.New("gitlab is not supported yet. Check back soon")
 	case Github:
-		return &githubManager{conf: conf, repo: repo}, nil
+		return newGithubManager(conf, repo)
 	default:
 		return nil, fmt.Errorf(
 			"unsupported source code host. expected one of the following: %s %s %s but got %s",


### PR DESCRIPTION
# Description 

The changes in this pull request resolve a critical issue that was discovered when trying to purge/remove code comments for multiple issues that were marked as `closed` in a separate personal project. 

The error seems to have stemmed from a race condition due to re-creating http headers and a request url on each status check request, and then assigning them to a receiver. In other words, if we are checking the status of 10 reported issues, 10 go routines would spawn and each one would attempt to reassign headers and  a request URL with a query param that contains the issue number of the issue we are trying to check the status of.

The fix was quite simple, I constructed the request headers only once when initializing the `github manager` struct and then on each status request, a new url is created and is not written to the receiver (`github manager`). 